### PR TITLE
Auto-assign drivers to new WooCommerce orders

### DIFF
--- a/admin/ddwc-functions.php
+++ b/admin/ddwc-functions.php
@@ -141,3 +141,72 @@ function ddwc_check_user_roles( $roles, $user_id = null ) {
 
     return false;
 }
+
+/**
+ * Auto-assign a delivery driver to new orders.
+ *
+ * Selects an available driver based on the configured algorithm and stores
+ * the driver ID in the order's meta data.
+ *
+ * @since 2.5.0
+ *
+ * @param int $order_id Order ID.
+ */
+function ddwc_auto_assign_driver_to_order( $order_id ) {
+
+        // Bail if a driver is already assigned.
+        if ( get_post_meta( $order_id, 'ddwc_driver_id', true ) ) {
+                return;
+        }
+
+        // Get available drivers.
+        $driver_args = array(
+                'role'       => 'driver',
+                'meta_key'   => 'ddwc_driver_availability',
+                'meta_value' => 'on',
+        );
+        $drivers     = get_users( $driver_args );
+
+        if ( empty( $drivers ) ) {
+                return;
+        }
+
+        // Determine assignment algorithm.
+        $algorithm = get_option( 'ddwc_settings_assignment_algorithm', 'least_orders' );
+        $driver_id = 0;
+
+        if ( 'random' === $algorithm ) {
+                $driver    = $drivers[ array_rand( $drivers ) ];
+                $driver_id = $driver->ID;
+        } else {
+                $least_orders = null;
+                foreach ( $drivers as $driver ) {
+                        $order_args = array(
+                                'post_type'      => 'shop_order',
+                                'post_status'    => array( 'wc-driver-assigned', 'wc-out-for-delivery' ),
+                                'meta_key'       => 'ddwc_driver_id',
+                                'meta_value'     => $driver->ID,
+                                'fields'         => 'ids',
+                                'posts_per_page' => -1,
+                        );
+                        $open_orders = get_posts( $order_args );
+                        $count       = count( $open_orders );
+
+                        if ( is_null( $least_orders ) || $count < $least_orders ) {
+                                $least_orders = $count;
+                                $driver_id    = $driver->ID;
+                        }
+                }
+        }
+
+        if ( $driver_id ) {
+                update_post_meta( $order_id, 'ddwc_driver_id', $driver_id );
+
+                // Update order status to show driver assignment.
+                $order = wc_get_order( $order_id );
+                if ( $order ) {
+                        $order->update_status( 'driver-assigned' );
+                }
+        }
+}
+add_action( 'woocommerce_new_order', 'ddwc_auto_assign_driver_to_order' );

--- a/admin/ddwc-woocommerce-settings.php
+++ b/admin/ddwc-woocommerce-settings.php
@@ -121,21 +121,33 @@ class Delivery_Drivers_WooCommerce_Settings {
 				),
 			),
 			// Driver phone number.
-			'driver_phone_number' => array(
-				'name' => __( 'Driver phone number', 'ddwc' ),
-				'type' => 'select',
-				'desc' => __( 'Add a button for customers to call driver in the driver details.', 'ddwc' ),
-				'id'   => 'ddwc_settings_driver_phone_number',
-				'options' => array(
-					'yes' => 'Yes',
-					'no'  => 'No',
-				),
-			),
-			// Section End.
-			'section_end' => array(
-				'type' => 'sectionend',
-				'id'   => 'ddwc_settings_section_end'
-			),
+                        'driver_phone_number' => array(
+                                'name' => __( 'Driver phone number', 'ddwc' ),
+                                'type' => 'select',
+                                'desc' => __( 'Add a button for customers to call driver in the driver details.', 'ddwc' ),
+                                'id'   => 'ddwc_settings_driver_phone_number',
+                                'options' => array(
+                                        'yes' => 'Yes',
+                                        'no'  => 'No',
+                                ),
+                        ),
+                       // Driver assignment algorithm.
+                       'assignment_algorithm' => array(
+                               'name'    => __( 'Driver assignment algorithm', 'ddwc' ),
+                               'type'    => 'select',
+                               'desc'    => __( 'Select how drivers are assigned to new orders.', 'ddwc' ),
+                               'id'      => 'ddwc_settings_assignment_algorithm',
+                               'default' => 'least_orders',
+                               'options' => array(
+                                       'least_orders' => __( 'Least open deliveries', 'ddwc' ),
+                                       'random'       => __( 'Random', 'ddwc' ),
+                               ),
+                       ),
+                        // Section End.
+                        'section_end' => array(
+                                'type' => 'sectionend',
+                                'id'   => 'ddwc_settings_section_end'
+                        ),
 		);
 		return apply_filters( 'ddwc_woocommerce_settings', $settings );
 


### PR DESCRIPTION
## Summary
- automatically assign an available driver whenever an order is created
- allow admin to choose algorithm (least open deliveries or random) in settings

## Testing
- `php -l admin/ddwc-functions.php`
- `php -l admin/ddwc-woocommerce-settings.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4644cac908323be01f9be8dc26b5a