### PR TITLE
Add Twilio SMS helper and settings

### DIFF
--- a/admin/class-ddwc-admin.php
+++ b/admin/class-ddwc-admin.php
@@ -194,6 +194,15 @@ function ddwc_delivery_driver_settings() {
 		$order->update_status( 'processing' );
 	} else {
 		$order->update_status( 'driver-assigned' );
+
+                // Send SMS notification to driver.
+                $driver_phone   = get_user_meta( $meta_value, 'billing_phone', true );
+                $dispatch_phone = get_option( 'ddwc_settings_dispatch_phone_number' );
+                if ( $driver_phone && $dispatch_phone ) {
+                        $twilio  = new Delivery_Drivers_Twilio();
+                        $message = sprintf( __( 'You have been assigned to order #%s', 'ddwc' ), $item_id );
+                        $twilio->send_sms( $driver_phone, $dispatch_phone, $message );
+                }
 	}
 
 	// WooCommerce product loop $args

--- a/admin/ddwc-functions.php
+++ b/admin/ddwc-functions.php
@@ -41,6 +41,14 @@ function ddwc_driver_dashboard_change_statuses() {
 
 		// Run additional functions.
 		do_action( 'ddwc_email_customer_order_status_out_for_delivery' );
+                // Send SMS notification to customer.
+                $customer_phone = $order->get_billing_phone();
+                $dispatch_phone = get_option( 'ddwc_settings_dispatch_phone_number' );
+                if ( $customer_phone && $dispatch_phone ) {
+                        $twilio  = new Delivery_Drivers_Twilio();
+                        $message = sprintf( __( 'Your order #%s is out for delivery.', 'ddwc' ), $order->get_id() );
+                        $twilio->send_sms( $customer_phone, $dispatch_phone, $message );
+                }
 
 		// Redirect so the new order details show on the page.
 		wp_redirect( get_permalink( get_option( 'woocommerce_myaccount_page_id' ) ) . 'driver-dashboard/?orderid=' . $_GET['orderid'] );
@@ -55,6 +63,14 @@ function ddwc_driver_dashboard_change_statuses() {
 
 		// Run additional functions.
 		do_action( 'ddwc_email_admin_order_status_completed' );
+                // Send SMS notification to customer.
+                $customer_phone = $order->get_billing_phone();
+                $dispatch_phone = get_option( 'ddwc_settings_dispatch_phone_number' );
+                if ( $customer_phone && $dispatch_phone ) {
+                        $twilio  = new Delivery_Drivers_Twilio();
+                        $message = sprintf( __( 'Your order #%s has been delivered.', 'ddwc' ), $order->get_id() );
+                        $twilio->send_sms( $customer_phone, $dispatch_phone, $message );
+                }
 
 		// Redirect so the new order details show on the page.
 		wp_redirect( get_permalink( get_option( 'woocommerce_myaccount_page_id' ) ) . 'driver-dashboard/?orderid=' . $_GET['orderid'] );

--- a/admin/ddwc-woocommerce-settings.php
+++ b/admin/ddwc-woocommerce-settings.php
@@ -131,6 +131,20 @@ class Delivery_Drivers_WooCommerce_Settings {
 					'no'  => 'No',
 				),
 			),
+                        // Twilio Account SID.
+                        'twilio_account_sid' => array(
+                                'name' => __( 'Twilio Account SID', 'ddwc' ),
+                                'type' => 'text',
+                                'desc' => __( 'Twilio account SID used for sending SMS notifications.', 'ddwc' ),
+                                'id'   => 'ddwc_settings_twilio_account_sid',
+                        ),
+                        // Twilio Auth Token.
+                        'twilio_auth_token' => array(
+                                'name' => __( 'Twilio Auth Token', 'ddwc' ),
+                                'type' => 'password',
+                                'desc' => __( 'Twilio auth token used for sending SMS notifications.', 'ddwc' ),
+                                'id'   => 'ddwc_settings_twilio_auth_token',
+                        ),
 			// Section End.
 			'section_end' => array(
 				'type' => 'sectionend',

--- a/includes/class-ddwc-twilio.php
+++ b/includes/class-ddwc-twilio.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Twilio helper class.
+ *
+ * Provides a wrapper around the Twilio PHP SDK for sending SMS messages.
+ *
+ * @link       https://www.deviodigital.com
+ * @since      2.4.3
+ *
+ * @package    DDWC
+ * @subpackage DDWC/includes
+ */
+
+if ( ! class_exists( 'Delivery_Drivers_Twilio' ) ) {
+/**
+ * Helper class to send SMS messages via Twilio.
+ */
+class Delivery_Drivers_Twilio {
+
+/**
+ * Twilio REST client instance.
+ *
+ * @var \Twilio\Rest\Client|null
+ */
+protected $client = null;
+
+/**
+ * Setup Twilio client using saved credentials.
+ */
+public function __construct() {
+$sid   = get_option( 'ddwc_settings_twilio_account_sid' );
+$token = get_option( 'ddwc_settings_twilio_auth_token' );
+
+if ( $sid && $token && class_exists( '\\Twilio\\Rest\\Client' ) ) {
+$this->client = new \Twilio\Rest\Client( $sid, $token );
+}
+}
+
+/**
+ * Send an SMS message via Twilio.
+ *
+ * @param string $to      Recipient phone number.
+ * @param string $from    Sender phone number.
+ * @param string $message Message body.
+ *
+ * @return bool True on success, false on failure.
+ */
+public function send_sms( $to, $from, $message ) {
+if ( empty( $this->client ) ) {
+return false;
+}
+
+try {
+$this->client->messages->create(
+$to,
+array(
+'from' => $from,
+'body' => $message,
+)
+);
+return true;
+} catch ( \Exception $e ) {
+return false;
+}
+}
+}
+}

--- a/includes/class-ddwc.php
+++ b/includes/class-ddwc.php
@@ -154,6 +154,11 @@ class DDWC {
 		 */
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/ddwc-woocommerce-driver-ratings.php';
 
+                /**
+                 * The class responsible for sending SMS via Twilio.
+                 */
+                require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-ddwc-twilio.php';
+
 		/**
 		 * The class responsible for defining all actions that occur in the public-facing
 		 * side of the site.


### PR DESCRIPTION
## Summary
- add Twilio helper class for sending SMS messages
- expose Twilio Account SID and Auth Token settings
- send SMS notifications to drivers and customers on assignment and status changes

## Testing
- `php -l includes/class-ddwc-twilio.php`
- `php -l includes/class-ddwc.php`
- `php -l admin/ddwc-woocommerce-settings.php`
- `php -l admin/class-ddwc-admin.php`
- `php -l admin/ddwc-functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4645ade208323a13e5a96332da3c0