### PR TITLE
Notify drivers of new assignments

### DIFF
--- a/admin/class-ddwc-admin.php
+++ b/admin/class-ddwc-admin.php
@@ -179,22 +179,29 @@ add_filter( 'post_class', 'ddwc_add_no_link_to_woocommerce_orders' );
  */
 function ddwc_delivery_driver_settings() {
 
-	$item_id    = $_POST['item_id'];
-	$meta_key   = $_POST['metakey'];
-	$meta_value = $_POST['metavalue'];
+        $item_id    = $_POST['item_id'];
+        $meta_key   = $_POST['metakey'];
+        $meta_value = $_POST['metavalue'];
 
-	// Update driver ID for order.
-	update_post_meta( $item_id, $meta_key, $meta_value );
+        // Store previous driver to detect changes.
+        $previous_driver = get_post_meta( $item_id, $meta_key, true );
 
-	// Get order.
-	$order = new WC_Order( $item_id );
+        // Update driver ID for order.
+        update_post_meta( $item_id, $meta_key, $meta_value );
 
-	// Update order status.
-	if ( -1 == $meta_value ) {
-		$order->update_status( 'processing' );
-	} else {
-		$order->update_status( 'driver-assigned' );
-	}
+        // Get order.
+        $order = new WC_Order( $item_id );
+
+        // Update order status and trigger notification when assigning a driver.
+        if ( -1 == $meta_value ) {
+                $order->update_status( 'processing' );
+        } else {
+                $order->update_status( 'driver-assigned' );
+
+                if ( intval( $meta_value ) > 0 && intval( $meta_value ) !== intval( $previous_driver ) ) {
+                        do_action( 'ddwc_driver_assigned', $item_id, intval( $meta_value ) );
+                }
+        }
 
 	// WooCommerce product loop $args
 	$args = array(


### PR DESCRIPTION
## Summary
- send email and Twilio SMS when an order is assigned to a driver
- trigger notification from manual driver assignment actions
- hook notification into automatic assignment action for coverage

## Testing
- `php -l admin/ddwc-functions.php`
- `php -l admin/ddwc-metaboxes.php`
- `php -l admin/class-ddwc-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4646bbcc88323962ab8104644e328