### PR TITLE
Fix typo in README driver capabilities heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This plugin gives you the ability to add new users with the designated `Driver` 
 
 Once the driver has been added to your userlist, you can edit orders and assign a specific driver to the order.
 
-### Driver capabilites
+### Driver capabilities
 
 Give your drivers the ability to view their assigned orders, mark an order as `Out for Delivery` and then `Completed` after the order has been delivered.
 


### PR DESCRIPTION
## Summary
- correct spelling error in README section title from "Driver capabilites" to "Driver capabilities"

## Testing
- `npm test` (fails: Could not read package.json)
- `composer test` (fails: Command "test" is not defined)
- `phpunit` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a468b171688323aca1ca865a98d0be