### PR TITLE
docs: clarify delivery driver column comment

### DIFF
--- a/admin/class-ddwc-admin.php
+++ b/admin/class-ddwc-admin.php
@@ -83,7 +83,7 @@ class Delivery_Drivers_Admin {
 }
 
 /**
- * Add Deliver Driver Column to Orders screen
+ * Add Delivery Driver Column to Orders screen
  *
  * @param [type] $columns
  * @since 2.1


### PR DESCRIPTION
## Summary
- fix typo in order screen delivery driver column docblock

## Testing
- `php -l admin/class-ddwc-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68a468b6dd888323b20ff4c87206a883