### PR TITLE
Add unit tests for ddwc_check_user_roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,13 @@ Below are a few examples of delivery services that can benefit from the **Delive
 ## Changelog
 
 View [CHANGELOG.md](https://github.com/robertdevore/delivery-drivers-for-woocommerce/blob/master/CHANGELOG.md)
+## Tests
+
+This plugin uses the WordPress unit test framework with PHPUnit.
+
+1. Install the WordPress tests library and configure the `WP_TESTS_DIR` environment variable.
+2. From the plugin directory, run:
+
+   ```bash
+   phpunit
+   ```

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Plugin Tests">
+            <directory suffix=".php">tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * PHPUnit bootstrap file for Delivery Drivers for WooCommerce.
+ */
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+
+if ( ! $_tests_dir ) {
+    $_tests_dir = '/tmp/wordpress-tests-lib';
+}
+
+require_once $_tests_dir . '/includes/functions.php';
+
+// Load this plugin.
+tests_add_filter( 'muplugins_loaded', function () {
+    require dirname( __DIR__ ) . '/delivery-drivers-for-woocommerce.php';
+} );
+
+require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/test-ddwc-check-user-roles.php
+++ b/tests/test-ddwc-check-user-roles.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Tests for ddwc_check_user_roles helper function.
+ */
+
+class DDWCTest_Check_User_Roles extends WP_UnitTestCase {
+
+    /**
+     * Should return true when user has a matching role.
+     */
+    public function test_returns_true_with_correct_role() {
+        $user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+        $this->assertTrue( ddwc_check_user_roles( [ 'administrator' ], $user_id ) );
+    }
+
+    /**
+     * Should return false when user lacks the required role.
+     */
+    public function test_returns_false_without_role() {
+        $user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+        $this->assertFalse( ddwc_check_user_roles( [ 'administrator' ], $user_id ) );
+    }
+
+    /**
+     * Should return false when an unknown user ID is provided.
+     */
+    public function test_returns_false_with_invalid_user_id() {
+        $this->assertFalse( ddwc_check_user_roles( [ 'subscriber' ], 999999 ) );
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPUnit/WordPress unit test for `ddwc_check_user_roles`
- document running tests in README
- add basic PHPUnit configuration and bootstrap

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a468b7e51c83238b75020e58c4df9c