### PR TITLE
Fix parse error and clean up admin notification function

### DIFF
--- a/admin/ddwc-functions.php
+++ b/admin/ddwc-functions.php
@@ -419,12 +419,6 @@ function ddwc_notify_admin_order_completed() {
                         ),
                 );
 
-// codex/add-email/sms-notifications-for-order-status
-                wp_remote_post( $endpoint, $args );
-        }
-}
-add_action( 'ddwc_email_customer_order_status_out_for_delivery', 'ddwc_customer_out_for_delivery_notification' );
-
                 $response = wp_remote_post( $twilio_url, $sms_args );
 
                 if ( $logger ) {
@@ -435,7 +429,8 @@ add_action( 'ddwc_email_customer_order_status_out_for_delivery', 'ddwc_customer_
                         } else {
                                 $logger->error( 'Failed to send admin completion SMS for order #' . $order_id, array( 'source' => 'ddwc' ) );
                         }
-                } elseif ( $logger ) {
+                }
+        } elseif ( $logger ) {
                 $logger->warning( 'Admin completion SMS not sent for order #' . $order_id . ' due to missing Twilio configuration or phone number.', array( 'source' => 'ddwc' ) );
         }
 }


### PR DESCRIPTION
## Summary
- fix unmatched brace in `admin/ddwc-functions.php`
- remove duplicated hook and send Twilio SMS inside conditional

## Testing
- `php -l admin/ddwc-functions.php`
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`
- `phpunit` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a4764dc63483239002a9f370ac9a49