### PR TITLE
Use live checkbox state for driver availability

### DIFF
--- a/public/js/ddwc-public.js
+++ b/public/js/ddwc-public.js
@@ -48,7 +48,7 @@ jQuery(document).ready(function ($) {
     jQuery('.ddwc-availability label.switch input[type=checkbox]').change(function(e) {
         var user_id = $(this).attr('id');
         var metakey = 'ddwc_driver_availability';
-        var metavalue = $(this).attr('checked');
+        var metavalue = $(this).is(':checked') ? 'checked' : '';
         $.post(WPaAjax.ajaxurl,{
             action : 'ddwc_driver_availability_update',
             user_id : user_id,


### PR DESCRIPTION
## Summary
- ensure driver availability AJAX uses checkbox's live state

## Testing
- `phpunit` *(command not found)*
- `apt-get update` *(403 errors fetching repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68a5987678b88323ab067205c8926613